### PR TITLE
refactor: remove guppy3 unnecessary dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-20.04, macOS-10.15]
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macOS-10.15]
+        os: [ubuntu-20.04]
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ docker run -it quay.io/biocontainers/tin-score-calculation:0.4--pyh5e36f6f_0 plo
 
 ## Version
 
-0.5.0
+0.5.1
 
 ## Contact
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 bx-python>=0.8.10
-guppy3>=3.1.0
 matplotlib>=3.3.4
 pandas>=1.2.3
 psutil>=5.8.0

--- a/scripts/calculate-tin.py
+++ b/scripts/calculate-tin.py
@@ -44,8 +44,6 @@ __email__ = "wang.liguo@mayo.edu"
 __status__ = "Production"
 __multithreadingBy__ = "Mihaela Zavolan"
 
-h = hpy()
-
 
 def printlog(mesg):
     """

--- a/scripts/calculate-tin.py
+++ b/scripts/calculate-tin.py
@@ -25,7 +25,6 @@ import warnings
 
 from bx.intervals import Intersecter, Interval
 from qcmodule import BED
-from guppy import hpy
 import numpy as np
 import pysam
 
@@ -542,10 +541,6 @@ def main():
     # clean up processes
     pool.close()
     pool.join()
-
-
-#    hout = h.heap()
-#    print(hout.byrcs)
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='tin-score-calculation',
-    version='0.5',
+    version='0.5.1',
     description="",
     url='',
     include_package_data=True,


### PR DESCRIPTION
## Description

Remove old unnecessary dependency for tin score calculation: `guppy3`, it was not used anywhere in the code actually.

Fixes #19 

## Type of change

- [x] Refactoring

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
